### PR TITLE
Added tool that supports different languages for fetching swedish data from convex

### DIFF
--- a/frontend/convex/chat.ts
+++ b/frontend/convex/chat.ts
@@ -1,48 +1,16 @@
 import { action } from './_generated/server';
-import { searchRagChunks } from './ragSearch';
 import { createGoogleGenerativeAI } from '@ai-sdk/google';
 import { generateText } from 'ai';
 import { v } from 'convex/values';
+import { buildChatMessages, createRagSearchTool, SYSTEM_PROMPT } from './chatRag';
 
 const DEFAULT_MODEL = 'gemini-3-flash-preview';
 const DEFAULT_RAG_LIMIT = 6;
-const SYSTEM_PROMPT =
-  'You are Clarus, a helpful Swedish legal assistant. Be clear, concise, and avoid legal advice.';
 const env =
   (globalThis as { process?: { env?: Record<string, string | undefined> } }).process?.env ?? {};
 const getApiKey = () => env.GEMINI_API_KEY?.trim();
 const resolveModel = () => env.GEMINI_MODEL?.trim() || DEFAULT_MODEL;
 const isRagEnabled = () => (env.RAG_ENABLED?.trim().toLowerCase() ?? 'true') !== 'false';
-
-const normalizeRole = (role: string) =>
-  role === 'assistant' || role === 'model' ? 'Assistant' : 'User';
-
-const buildPrompt = (
-  message: string,
-  history?: Array<{ role: string; content: string }>,
-  ragContext?: string,
-) => {
-  const lines = [SYSTEM_PROMPT];
-
-  if (ragContext) {
-    lines.push(
-      [
-        'Use the following retrieval context if it is relevant to the user question.',
-        'If the context is insufficient, clearly say what is uncertain.',
-        '',
-        ragContext,
-      ].join('\n'),
-    );
-  }
-
-  for (const item of history ?? []) {
-    lines.push(`${normalizeRole(item.role)}: ${item.content}`);
-  }
-
-  lines.push(`User: ${message}`);
-
-  return lines.join('\n\n');
-};
 
 export const sendMessage = action({
   args: {
@@ -69,7 +37,16 @@ export const sendMessage = action({
       };
     }
 
-    let ragContext = '';
+    const google = createGoogleGenerativeAI({ apiKey });
+    const messages = buildChatMessages(args.message, args.history);
+    const tools = isRagEnabled()
+      ? {
+          rag_search_sv: createRagSearchTool(ctx, {
+            siteId: args.rag_site_id,
+            limit: args.rag_limit ?? DEFAULT_RAG_LIMIT,
+          }),
+        }
+      : undefined;
     let citations: Array<{
       id: string;
       title: string;
@@ -78,27 +55,22 @@ export const sendMessage = action({
       source_type: string;
     }> = [];
 
-    if (isRagEnabled()) {
-      try {
-        const ragResult = await searchRagChunks(ctx, {
-          query: args.message,
-          site_id: args.rag_site_id,
-          lang: args.rag_lang,
-          limit: args.rag_limit ?? DEFAULT_RAG_LIMIT,
-        });
-
-        ragContext = ragResult.context;
-        citations = ragResult.citations;
-      } catch (error) {
-        console.error('RAG search failed for chat request', error);
-      }
-    }
-
-    const google = createGoogleGenerativeAI({ apiKey });
-    const prompt = buildPrompt(args.message, args.history, ragContext);
     const result = await generateText({
       model: google(resolveModel()),
-      prompt,
+      system: SYSTEM_PROMPT,
+      messages,
+      tools,
+      maxSteps: isRagEnabled() ? 4 : 1,
+      onStepFinish: ({ toolResults }) => {
+        for (const toolResult of toolResults ?? []) {
+          if (toolResult.toolName === 'rag_search_sv') {
+            const ragResult = toolResult.result as {
+              citations?: typeof citations;
+            };
+            citations = ragResult?.citations ?? [];
+          }
+        }
+      },
     });
     const answer = result.text?.trim() || 'No response generated.';
 

--- a/frontend/convex/chatRag.ts
+++ b/frontend/convex/chatRag.ts
@@ -1,0 +1,86 @@
+import { tool } from 'ai';
+import { z } from 'zod';
+import { RagSearchResult, searchRagChunks } from './ragSearch';
+
+export const SYSTEM_PROMPT = [
+  'You are Clarus, a helpful legal assistant. Be clear, concise, and avoid legal advice.',
+  "Answer in the user's language.",
+  '',
+  'When factual or legal grounding is needed, call tool rag_search_sv.',
+  'Before calling, rewrite the user intent into Swedish search queries.',
+  'Keep queries short and focused; include Swedish legal terms and synonyms.',
+  'If results are empty, broaden Swedish terms and retry once (tool also falls back).',
+  '',
+  'Use retrieved context and cite sources. If context is insufficient, say so.',
+  'Do not call the tool for greetings or general chit-chat.',
+].join('\n');
+
+export type ChatMessage = {
+  role: 'user' | 'assistant';
+  content: string;
+};
+
+const emptyRagResult = (): RagSearchResult => ({
+  context: '',
+  citations: [],
+  embedding_model: 'unknown',
+  total_candidates: 0,
+  total_matches: 0,
+});
+
+const normalizeMessageRole = (role: string): ChatMessage['role'] =>
+  role === 'assistant' || role === 'model' ? 'assistant' : 'user';
+
+export const buildChatMessages = (
+  message: string,
+  history?: Array<{ role: string; content: string }>,
+): ChatMessage[] => {
+  const messages = (history ?? []).map((item) => ({
+    role: normalizeMessageRole(item.role),
+    content: item.content,
+  }));
+
+  messages.push({ role: 'user', content: message });
+  return messages;
+};
+
+type SearchContext = Parameters<typeof searchRagChunks>[0];
+
+export const createRagSearchTool = (
+  ctx: SearchContext,
+  options?: { siteId?: string; limit?: number },
+) =>
+  tool({
+    description: 'Search Swedish legal sources. Input must be Swedish.',
+    parameters: z.object({
+      query_sv: z.string().min(1).describe('Swedish search query'),
+      site_id: z.string().optional().describe('Override site id'),
+      limit: z.number().int().positive().optional().describe('Max results'),
+    }),
+    execute: async ({ query_sv, site_id, limit }) => {
+      const resolvedSiteId = site_id ?? options?.siteId;
+      const resolvedLimit = limit ?? options?.limit;
+
+      try {
+        const primary = await searchRagChunks(ctx, {
+          query: query_sv,
+          site_id: resolvedSiteId,
+          lang: 'sv',
+          limit: resolvedLimit,
+        });
+
+        if (primary.total_matches > 0) {
+          return primary;
+        }
+
+        return await searchRagChunks(ctx, {
+          query: query_sv,
+          site_id: resolvedSiteId,
+          limit: resolvedLimit,
+        });
+      } catch (error) {
+        console.error('RAG tool failed', error);
+        return emptyRagResult();
+      }
+    },
+  });

--- a/frontend/convex/http.ts
+++ b/frontend/convex/http.ts
@@ -3,30 +3,16 @@ import { streamText } from 'ai';
 import { httpRouter } from 'convex/server';
 
 import { httpAction } from './_generated/server';
+import { buildChatMessages, createRagSearchTool, SYSTEM_PROMPT } from './chatRag';
 
 const DEFAULT_MODEL = 'gemini-3-flash-preview';
 const DEFAULT_ORIGIN = 'http://localhost:5173';
-const SYSTEM_PROMPT =
-  'You are Clarus, a helpful Swedish legal assistant. Be clear, concise, and avoid legal advice.';
+const DEFAULT_RAG_LIMIT = 6;
 const env =
   (globalThis as { process?: { env?: Record<string, string | undefined> } }).process?.env ?? {};
 const getApiKey = () => env.GEMINI_API_KEY?.trim();
 const resolveModel = () => env.GEMINI_MODEL?.trim() || DEFAULT_MODEL;
-
-const normalizeRole = (role: string) =>
-  role === 'assistant' || role === 'model' ? 'Assistant' : 'User';
-
-const buildPrompt = (message: string, history?: Array<{ role: string; content: string }>) => {
-  const lines = [SYSTEM_PROMPT];
-
-  for (const item of history ?? []) {
-    lines.push(`${normalizeRole(item.role)}: ${item.content}`);
-  }
-
-  lines.push(`User: ${message}`);
-
-  return lines.join('\n\n');
-};
+const isRagEnabled = () => (env.RAG_ENABLED?.trim().toLowerCase() ?? 'true') !== 'false';
 
 const corsHeaders = (origin: string) => {
   const headers = new Headers();
@@ -43,7 +29,7 @@ const http = httpRouter();
 http.route({
   path: '/chat/stream',
   method: 'OPTIONS',
-  handler: httpAction(async (_ctx, request) => {
+  handler: httpAction(async (ctx, request) => {
     const origin = request.headers.get('Origin') ?? env.CLIENT_ORIGIN ?? DEFAULT_ORIGIN;
     return new Response(null, { headers: corsHeaders(origin) });
   }),
@@ -52,7 +38,7 @@ http.route({
 http.route({
   path: '/chat/stream',
   method: 'POST',
-  handler: httpAction(async (_ctx, request) => {
+  handler: httpAction(async (ctx, request) => {
     const origin = request.headers.get('Origin') ?? env.CLIENT_ORIGIN ?? DEFAULT_ORIGIN;
     const headers = corsHeaders(origin);
     const apiKey = getApiKey();
@@ -67,10 +53,21 @@ http.route({
 
     try {
       const google = createGoogleGenerativeAI({ apiKey });
-      const prompt = buildPrompt(body.message, body.history);
+      const messages = buildChatMessages(body.message, body.history);
+      const tools = isRagEnabled()
+        ? {
+            rag_search_sv: createRagSearchTool(ctx, {
+              siteId: body.rag_site_id,
+              limit: body.rag_limit ?? DEFAULT_RAG_LIMIT,
+            }),
+          }
+        : undefined;
       const result = streamText({
         model: google(resolveModel()),
-        prompt,
+        system: SYSTEM_PROMPT,
+        messages,
+        tools,
+        maxSteps: isRagEnabled() ? 4 : 1,
       });
       const reader = result.textStream.getReader();
       const encoder = new TextEncoder();


### PR DESCRIPTION
### **Added tool that supports different languages for fetching swedish data from convex**

- Added `chatRag.ts` to define a tool-driven RAG flow where the LLM rewrites queries into Swedish and calls `rag_search_sv` with a Swedish-only filter plus a fallback to no language filter. Updated both action and streaming chat paths to use the same tool-based prompt/retrieval logic, and to surface citations from tool results.